### PR TITLE
ServiceData must be a bytearray

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
         awk -F '\/' '{ print tolower($2) }' |
         tr '_' '-'
         )
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Versions
       run: |
         python3 --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
         awk -F '\/' '{ print tolower($2) }' |
         tr '_' '-'
         )
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Versions
       run: |
         python3 --version

--- a/adafruit_ble_eddystone/__init__.py
+++ b/adafruit_ble_eddystone/__init__.py
@@ -58,7 +58,8 @@ class _EddystoneFrame(ServiceData):
         return super().__get__(obj, cls)[1:]
 
     def __set__(self, obj, value):
-        return super().__set__(obj, obj.frame_type + value)
+        # ServiceData requires a bytearray.
+        return super().__set__(obj, bytearray(obj.frame_type) + value)
 
 
 class EddystoneFrameBytes:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-# autodoc_mock_imports = ["digitalio", "busio"]
+autodoc_mock_imports = ["bleak"]
 
 
 intersphinx_mapping = {


### PR DESCRIPTION
Fixes #9.

`example/ble_eddystone_simpletest.py` was failing because `ServiceData.__set__()` was expecting a `bytearray`, not a `bytes`.

Tested with fix. @kbm15: thanks for the report! See if this works for you.

