### PR TITLE
Pass entry through

### DIFF
--- a/adafruit_ble_eddystone/__init__.py
+++ b/adafruit_ble_eddystone/__init__.py
@@ -94,8 +94,11 @@ class EddystoneAdvertisement(Advertisement):
     services = ServiceList(standard_services=[0x03], vendor_services=[0x07])
     eddystone_frame = _EddystoneFrame()
 
-    def __init__(self, *, minimum_size=None):
-        super().__init__()
+    def __init__(self, *, minimum_size=None, entry=None):
+        super().__init__(entry=entry)
+        # Return early if things have been set by an existing ScanEntry.
+        if entry:
+            return
         self.services.append(_EddystoneService)
         self.connectable = False
         self.flags.general_discovery = True


### PR DESCRIPTION
This fixes creation from ScanEntry where we may have had
mixed state from __init__ and from_entry.

Depends on https://github.com/adafruit/Adafruit_CircuitPython_BLE/pull/123