### PR TITLE
Fix use of memoryview() + bytes()

### DIFF
--- a/adafruit_ble_eddystone/__init__.py
+++ b/adafruit_ble_eddystone/__init__.py
@@ -68,7 +68,7 @@ class EddystoneFrameBytes:
                 raise ValueError("Value length does not match")
             obj.eddystone_frame[self._offset : self._offset + self._length] = value
         else:
-            obj.eddystone_frame = obj.eddystone_frame[: self._offset] + value
+            obj.eddystone_frame = bytes(obj.eddystone_frame[: self._offset]) + value
 
 
 class EddystoneFrameStruct(EddystoneFrameBytes):


### PR DESCRIPTION
Concatenating a memoryview() with a bytes() no longer works as of CircuitPython 9, due to changes in MicroPython to match CPython. Thix fixes such a use.